### PR TITLE
Added "I'm feeling ducky" behavior to URL bar searches

### DIFF
--- a/data/search.xml
+++ b/data/search.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"> 
-  <ShortName>DuckDuckGo</ShortName> 
-  <Description>Search DuckDuckGo</Description> 
-  <InputEncoding>UTF-8</InputEncoding> 
-  <LongName>Search Plugin for DuckDuckGo (HTTPS version)</LongName> 
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>DuckDuckGo</ShortName>
+  <Description>Search DuckDuckGo</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <LongName>Search Plugin for DuckDuckGo (HTTPS version)</LongName>
   <Image width="16" height="16">http://duckduckgo.com/favicon.ico</Image>
+
+  <!-- Search bar query -->
   <Url type="text/html" method="get" template="https://duckduckgo.com/">
-    <Param name="q" value="{searchTerms}"/>  
+    <Param name="q" value="{searchTerms}"/>
   </Url>
+
+  <!-- URL bar query -->
+  <Url type="application/x-moz-keywordsearch" method="get" template="https://duckduckgo.com/">
+    <Param name="q" value="! {searchTerms}"/>
+  </Url>
+
+  <!-- Auto-completion -->
   <Url type="application/x-suggestions+json" method="GET" template="https://duckduckgo.com/ac/">
     <Param name="q" value="{searchTerms}"/>
     <Param name="type" value="list"/>


### PR DESCRIPTION
Firefox supports the <Url> element type "application/x-moz-keywordsearch", which specifies what happens when a user types keywords into the address bar. This XML file will now let users search "I'm feeling ducky" from the URL bar, while ordinary search bar behavior is left unchanged.
