### PR TITLE
Add selected text to the search box

### DIFF
--- a/data/js/popup.js
+++ b/data/js/popup.js
@@ -101,9 +101,9 @@ self.port.on('opened', function(options) {
 
 
 
-  // putting last searched value to the input
-  if (options.last_search != undefined && options.last_search !== '' && options.last_search.length != 0) {
-      document.getElementById("search_form_input_homepage").value = options.last_search;
+  // putting selected text or last searched value to the input
+  if (options.selected_text || options.last_search != undefined && options.last_search !== '' && options.last_search.length != 0) {
+      document.getElementById("search_form_input_homepage").value = options.selected_text ? options.selected_text : options.last_search;
       document.getElementById("search_form_input_clear").style.display = 'inline-block';
       document.getElementById("search_button_homepage").className = 'selected';
       document.getElementById('search_form_input_homepage').select();

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -21,6 +21,7 @@ var prefSet = require("sdk/simple-prefs");
 var ss = require("sdk/simple-storage");
 var tabs = require("sdk/tabs");
 var { Hotkey } = require("sdk/hotkeys");
+var selection = require("sdk/selection");
 
 const {Cc,Cu,Ci,Cm} = require("chrome");
 
@@ -102,6 +103,7 @@ popupPanel.on('show', function() {
         feeling_ducky: ss.storage.ducky,
         show_meanings: ss.storage.meanings,
         zeroclick: prefSet.prefs['zeroclick'],
+        selected_text: selection.text,
         last_search: ((prefSet.prefs['remember_last_search'] == true) ? ss.storage.last_search : undefined),
         toolbar_button: prefSet.prefs['toolbar_button'],
         safe_search: prefSet.prefs['safe_search'],


### PR DESCRIPTION
A suggestion, whenever users select some text, copy it into the DDG Plus' search box. This way users can easily expand their search by selecting the text and opening search panel and then adding more text or changing the selected text.
