### PR TITLE
update: Hide ATB param and turn it on by defaut

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,9 @@
         {
                 "type": "bool",
                 "name": "atb_param",
-                "value": false,
-                "title": "Add ATB parameters to DuckDuckGo requests"
+                "value": true,
+                "title": "Add ATB parameters to DuckDuckGo requests",
+                "hidden": true
         },
         {
                 "type": "bool",


### PR DESCRIPTION
* Hide the ATB param setting and make it turned on by default.

Signed-off-by: mr.Shu <mr@shu.io>