### PR TITLE
update: Load ATB param from the site

### DIFF
--- a/data/js/duckduckgo.js
+++ b/data/js/duckduckgo.js
@@ -1,4 +1,16 @@
-self.port.emit('loaded');
+// grab the ATB param from the html element's class
+function getATBParam() {
+  var htmlClasslist = document.querySelector("html").classList;
+  for (var i = 0; i < htmlClasslist.length; i++) {
+    var cls = htmlClasslist[i];
+    if (cls.match(/^atb-/)) {
+      return cls.replace(/^atb-/, '');
+    }
+  }
+}
+
+var atbParam = getATBParam();
+self.port.emit('loaded', atbParam);
 self.port.on('on-install', function() {
 
   var atb = document.getElementById('atb-extension-overlay');

--- a/data/js/duckduckgo.js
+++ b/data/js/duckduckgo.js
@@ -1,12 +1,6 @@
 // grab the ATB param from the html element's class
 function getATBParam() {
-  var htmlClasslist = document.querySelector("html").classList;
-  for (var i = 0; i < htmlClasslist.length; i++) {
-    var cls = htmlClasslist[i];
-    if (cls.match(/^atb-/)) {
-      return cls.replace(/^atb-/, '');
-    }
-  }
+  return document.querySelector('html').getAttribute('data-atb');
 }
 
 var atbParam = getATBParam();

--- a/lib/ddg-oninstall.js
+++ b/lib/ddg-oninstall.js
@@ -29,7 +29,9 @@ exports.install = function (is_install) {
         worker.port.on('loaded', function(atbParam) {
           if (is_install) {
             // set the ATB param from the loaded site on install
-            ss.storage.atb = atbParam;
+            if (atbParam) {
+              ss.storage.atb = atbParam;
+            }
             worker.port.emit('on-install');
             // only fire the on-install event once
             is_install = false;

--- a/lib/ddg-oninstall.js
+++ b/lib/ddg-oninstall.js
@@ -17,6 +17,7 @@
 "use strict";
 
 var pageMod = require("sdk/page-mod");
+var ss = require("sdk/simple-storage");
 var pagemod;
 
 exports.install = function (is_install) {
@@ -25,8 +26,10 @@ exports.install = function (is_install) {
       contentScriptFile: './js/duckduckgo.js',
       attachTo: ["existing", "top"],
       onAttach: function(worker) {
-        worker.port.on('loaded', function() {
+        worker.port.on('loaded', function(atbParam) {
           if (is_install) {
+            // set the ATB param from the loaded site on install
+            ss.storage.atb = atbParam;
             worker.port.emit('on-install');
             // only fire the on-install event once
             is_install = false;


### PR DESCRIPTION
* Load the full ATB param from a class of the HTML element that can be
  found on the loaded duckduckgo.com site at install time.

Signed-off-by: mr.Shu <mr@shu.io>