### PR TITLE
fix: Fix Firefox v49 which requires restart

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -111,6 +111,14 @@ exports.main = function(options, callbacks) {
         ss.storage.meanings = true;
     }
 
+    // if the ATB parm is not defined, the extension is either being installed
+    // or we ran into a strange bug with Firefox v49 which requires a restart
+    // for the install of the first extension and never sends the 'install'
+    // trigger from options.loadReason
+    if (!ss.storage.atb) {
+      options.loadReason = "install";
+    }
+
     var is_install = false;
     // only set the atb parameter for new users
     if (options.loadReason == "install") {


### PR DESCRIPTION
* Fix a buggy version of Firefox (v49) which requires restart of Firefox
  if DuckDuckGo Plus is the first addon that is installed. The
  workaround is to check whether we have the ATB param set (it should be
  set at all times) and if we do not, force the code to behave like at
  install time.

Signed-off-by: mr.Shu <mr@shu.io>