### PR TITLE
test-main.js - fix main module path

### DIFF
--- a/test/test-main.js
+++ b/test/test-main.js
@@ -1,4 +1,4 @@
-const main = require("main");
+const main = require("../lib/main");
 
 exports.test_test_run = function(test) {
   test.pass("Unit test running!");


### PR DESCRIPTION
Tests were unable to run when using "jpm test" because the main module couldn't be found.
Results after the changes:
<pre>
18 of 21 tests passed.
There were test failures...
</pre>