### PR TITLE
add test for gmail logout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,80 +1,86 @@
 {
-    "description": "DuckDuckGo Plus",
-    "author": "DuckDuckGo",
-    "version": "1.1.1",
-    "title": "DuckDuckGo Plus",
-    "id": "jid1-ZAdIEUB7XOzOJw@jetpack",
-    "icon": {
-      "48": "icon_48.png",
-      "64": "icon_64.png"
+  "description": "DuckDuckGo Plus",
+  "author": "DuckDuckGo",
+  "version": "1.1.1",
+  "title": "DuckDuckGo Plus",
+  "id": "jid1-ZAdIEUB7XOzOJw@jetpack",
+  "icon": {
+    "48": "icon_48.png",
+    "64": "icon_64.png"
+  },
+  "name": "duckduckgo_plus",
+  "main": "lib/main.js",
+  "permissions": {
+    "multiprocess": true
+  },
+  "scripts": {
+    "test": "export PATH=$PATH:$PWD/node_modules/geckodriver/bin && node selenium-test/test.js && killall firefox-trunk"
+  },
+  "preferences": [
+    {
+      "type": "bool",
+      "name": "ddg_default",
+      "value": true,
+      "title": "DuckDuckGo as default (in search box and address bar)"
     },
-    "name": "duckduckgo_plus",
-    "main": "lib/main.js",
-    "permissions": {
-      "multiprocess": true
+    {
+      "type": "bool",
+      "name": "toolbar_button",
+      "value": true,
+      "title": "Show toolbar button (next to address bar)"
     },
-    "preferences": [
-        {
-                "type": "bool",
-                "name": "ddg_default",
-                "value": true,
-                "title": "DuckDuckGo as default (in search box and address bar)"
-        },
-        {
-                "type": "bool",
-                "name": "toolbar_button",
-                "value": true,
-                "title": "Show toolbar button (next to address bar)"
-        },
-        {
-                "type": "bool",
-                "name": "ask_dax",
-                "value": true,
-                "title": "Answers on right click (when you highlight words)"
-        },
-        {
-                "type": "bool",
-                "name": "use_hotkey",
-                "value": true,
-                "title": "Hotkey (Alt+G)"
-        },
-        {
-                "type": "bool",
-                "name": "remember_last_search",
-                "value": true,
-                "title": "Remember last search in the popup"
-        },
-        {
-                "type": "bool",
-                "name": "addressbar_autocomplete",
-                "value": true,
-                "title": "Show suggestions as you type in the address bar"
-        },
-        {
-                "type": "bool",
-                "name": "safe_search",
-                "value": true,
-                "title": "Use Safe Search (Omits objectionable (mostly adult) material).",
-                "hidden": true
-        },
-        {
-                "type": "bool",
-                "name": "no_popup",
-                "value": true,
-                "title": "Remove annoying Google marketing popups"
-        },
-        {
-                "type": "bool",
-                "name": "atb_param",
-                "value": true,
-                "title": "Add ATB parameters to DuckDuckGo requests",
-                "hidden": true
-        },
-        {
-                "type": "bool",
-                "name": "dev",
-                "value": false,
-                "title": "Show debug information"
-        }
-    ]
+    {
+      "type": "bool",
+      "name": "ask_dax",
+      "value": true,
+      "title": "Answers on right click (when you highlight words)"
+    },
+    {
+      "type": "bool",
+      "name": "use_hotkey",
+      "value": true,
+      "title": "Hotkey (Alt+G)"
+    },
+    {
+      "type": "bool",
+      "name": "remember_last_search",
+      "value": true,
+      "title": "Remember last search in the popup"
+    },
+    {
+      "type": "bool",
+      "name": "addressbar_autocomplete",
+      "value": true,
+      "title": "Show suggestions as you type in the address bar"
+    },
+    {
+      "type": "bool",
+      "name": "safe_search",
+      "value": true,
+      "title": "Use Safe Search (Omits objectionable (mostly adult) material).",
+      "hidden": true
+    },
+    {
+      "type": "bool",
+      "name": "no_popup",
+      "value": true,
+      "title": "Remove annoying Google marketing popups"
+    },
+    {
+      "type": "bool",
+      "name": "atb_param",
+      "value": true,
+      "title": "Add ATB parameters to DuckDuckGo requests",
+      "hidden": true
+    },
+    {
+      "type": "bool",
+      "name": "dev",
+      "value": false,
+      "title": "Show debug information"
+    }
+  ],
+  "dependencies": {
+    "selenium-webdriver": "^3.0.1"
+  }
 }

--- a/selenium-test/test.js
+++ b/selenium-test/test.js
@@ -1,0 +1,94 @@
+var firefox = require('selenium-webdriver/firefox');
+var webdriver = require('selenium-webdriver');
+var assert = require('selenium-webdriver/testing/assert');
+var until = webdriver.until;
+var By = webdriver.By;
+var process = require('process');
+var env = process.env;
+var fs = require('fs');
+
+var ddgEmail = env.DDG_TEST_EMAIL;
+var ddgEmailPw = env.DDG_TEST_EMAIL_PW;
+
+if(!ddgEmail || !ddgEmailPw){
+    console.log('Missing login user and pass');
+    process.exit(1);
+}
+
+var profile = new firefox.Profile();
+profile.addExtension( __dirname + '/../build/duckduckgo_plus.xpi');
+
+var options = new firefox.Options().setProfile(profile);
+var driver = new firefox.Driver(options);
+var capabilities = webdriver.Capabilities.firefox();
+capabilities.set('firefox_profile', profile);
+
+var wd = new webdriver.Builder()
+	.forBrowser('firefox')
+	.setFirefoxOptions(options)
+	.build();
+
+var ids = {
+    loginBtn: 'gb_70',
+    emailBox: 'Email',
+    emailSubmitBtn: 'next',
+    passwdBox: 'Passwd',
+    passSubmitBtn: 'signIn',
+    userIcon: 'gb_9a gbii',
+    userModal: 'gb_mb gb_ha gb_g',
+    signOutBtn: 'gb_71'
+};
+
+wd.get('http://google.com');
+wd.findElement({id: ids.loginBtn}).click().then(function() {
+
+        wd.wait(until.elementLocated( By.id(ids.emailBox)), 2000).then(function(emailBox) {
+            emailBox.sendKeys(ddgEmail);
+
+            wd.findElement({id: ids.emailSubmitBtn}).click();
+
+            wd.wait(until.elementLocated( By.id(ids.passwdBox)), 2000).then(function(passwordBox){
+                wd.wait(until.elementIsVisible(passwordBox), 2000).then(function(passwordBox){
+                    passwordBox.sendKeys(ddgEmailPw);
+                    wd.findElement({id: ids.passSubmitBtn}).click();
+
+                    wd.wait(until.elementLocated( By.className(ids.userIcon)), 4000, 'User icon should exist').then(function(userIcon) {
+                        // wait for page to completely load
+                        wd.sleep(4000).then(function(){
+                            wd.findElement(By.className('gb_9a gbii')).click();
+                            wd.findElement(By.className('gb_9a gbii')).click();
+                            
+                            // wait for modal
+                            wd.sleep(4000).then(function(){
+                                wd.takeScreenshot().then(function(img){
+                                    fs.writeFile('modal.png', img, 'base64');
+                                });
+
+                                wd.wait(until.elementLocated( By.className(ids.userModal)), 4000, 'Signout modal should exist').then( function(signoutModal){
+                                    wd.wait(until.elementIsVisible(signoutModal), 4000).then( function() {
+
+                                         wd.wait(until.elementLocated( By.id(ids.signOutBtn)), 2000, 'Signin button should exist').then(function(signoutBtn){
+                                                wd.findElement(By.id(ids.signOutBtn)).click().then(function(){
+                                                    
+                                                    // wait for logout and take screenshot to verify
+                                                    wd.sleep(5000).then(function(){
+                                                        // check to see that login button is back
+                                                        wd.wait(until.elementLocated(By.id(ids.loginBtn)), 2000);
+                                                        wd.takeScreenshot().then(function(img2){
+                                                            fs.writeFile('end.png', img2, 'base64');
+                                                            wd.close();
+                                                        });
+                                                    });
+                                                });
+                                        });
+                                    });
+                                });
+                            });
+
+                        });
+                    });
+                });
+            });
+        });
+});
+


### PR DESCRIPTION
Here's a test to make sure the extension doesn't break gmail logout again. It runs through the following tasks. 

- Installs the extension
- Navigate to google.com
- Login into a test account
- Click user icon in top right
- Click logout in the popup
- Check that "sign in" button is back

To verify the steps it will take a screenshot of the logout modal (modal.png) and the end logged out state (end.png).

There are a few requirements. 
- you have firefox nightly in order to automatically install the extension
- you have a built extension in the build directory
- running ubuntu with headless browser
- test gmail account credentials sourced in your environment 