### PR TITLE
Survey people who uninstall browser extension

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -225,5 +225,9 @@ exports.onUnload = function (reason) {
         Services.search.currentEngine = Services.search.getEngineByName(ss.storage.last_default_engine);
     }
 
+    if (reason == 'uninstall') {
+        window.open('https://www.surveymonkey.com/r/KFL2J7T');
+    }
+
     DDGAutocomplete.shutdown()
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -20,6 +20,7 @@ var self = require("sdk/self");
 
 var ss = require("sdk/simple-storage");
 var prefSet = require("sdk/simple-prefs");
+var windows = require("sdk/windows").browserWindows;
 
 const {Cc,Cu,Ci,Cm} = require("chrome");
 
@@ -226,7 +227,7 @@ exports.onUnload = function (reason) {
     }
 
     if (reason == 'uninstall') {
-        window.open('https://www.surveymonkey.com/r/KFL2J7T');
+        windows.open('https://www.surveymonkey.com/r/KFL2J7T');
     }
 
     DDGAutocomplete.shutdown()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "description": "DuckDuckGo Plus",
     "author": "DuckDuckGo",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "title": "DuckDuckGo Plus",
     "id": "jid1-ZAdIEUB7XOzOJw@jetpack",
     "icon": {


### PR DESCRIPTION
Reviewer: @jdorweiler 
cc: @bsstoner

I added a new `reason` for `uninstall` in `exports.onUnload` which should open a window with the survey in it. I have concerns about popup blockers, but I did some research and I think the basic `window.open` will serve.

This shouldn't be merged/released until the survey is ready to go, which should be by the end of the day today.