### PR TITLE
Pass day of churn data to uninstall survey redirect

### DIFF
--- a/lib/ddg-atbgen.js
+++ b/lib/ddg-atbgen.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016 DuckDuckGo, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+var ss = require("sdk/simple-storage");
+
+var atbTime = {
+    oneWeek     : 604800000,
+    oneDay      : 86400000,
+    oneHour     : 3600000,
+    oneMinute   : 60000,
+    estEpoch    : 1456290000000
+}
+
+var timeSinceEpoch = getTimeSinceEpoch(),
+    majorVersion = Math.ceil(timeSinceEpoch / atbTime.oneWeek),
+    minorVersion = Math.ceil(timeSinceEpoch % atbTime.oneWeek / atbTime.oneDay);
+
+
+function getTimeSinceEpoch() {
+    var localDate = new Date(),
+        localTime = localDate.getTime(),
+        utcTime = localTime + (localDate.getTimezoneOffset() * atbTime.oneMinute),
+        est = new Date(utcTime + (atbTime.oneHour * -5)),
+        dstStartDay = 13 - ((est.getFullYear() - 2016) % 6),
+        dstStopDay = 6 - ((est.getFullYear() - 2016) % 6),
+        isDST = (est.getMonth() > 2 || (est.getMonth() == 2 && est.getDate() >= dstStartDay)) && (est.getMonth() < 10 || (est.getMonth() == 10 && est.getDate() < dstStopDay)),
+        epoch = isDST ? atbTime.estEpoch - atbTime.oneHour : atbTime.estEpoch;
+
+    return new Date().getTime() - epoch;
+}
+
+// caluclate the current ATB on install
+exports.install = function () {
+    return 'v' + majorVersion + '-' + minorVersion;
+}
+
+// caluclate the day of churn on uninstall
+exports.uninstall = function () {
+    var ogMajorVersion = ss.storage.atb.split('-')[0].slice(1),
+        ogMinorVersion = ss.storage.atb.split('-')[1],
+        majorDiff = majorVersion - ogMajorVersion,
+        minorDiff = minorVersion - ogMinorVersion,
+        dayOfChurn = majorDiff > 0 ? (7 * majorDiff) + Math.abs(minorDiff) : minorDiff;
+
+    return dayOfChurn;
+
+}

--- a/lib/ddg-atbgen.js
+++ b/lib/ddg-atbgen.js
@@ -16,47 +16,41 @@
 
 "use strict";
 
-var ss = require("sdk/simple-storage");
+exports.calc = {
+    atbTime: {
+        oneWeek     : 604800000,
+        oneDay      : 86400000,
+        oneHour     : 3600000,
+        oneMinute   : 60000,
+        estEpoch    : 1456290000000
+    },
+    timeSinceEpoch: function() {
+        var localDate = new Date(),
+            localTime = localDate.getTime(),
+            utcTime = localTime + (localDate.getTimezoneOffset() * this.atbTime.oneMinute),
+            est = new Date(utcTime + (this.atbTime.oneHour * -5)),
+            dstStartDay = 13 - ((est.getFullYear() - 2016) % 6),
+            dstStopDay = 6 - ((est.getFullYear() - 2016) % 6),
+            isDST = (est.getMonth() > 2 || (est.getMonth() == 2 && est.getDate() >= dstStartDay)) && (est.getMonth() < 10 || (est.getMonth() == 10 && est.getDate() < dstStopDay)),
+            epoch = isDST ? this.atbTime.estEpoch - this.atbTime.oneHour : this.atbTime.estEpoch;
 
-var atbTime = {
-    oneWeek     : 604800000,
-    oneDay      : 86400000,
-    oneHour     : 3600000,
-    oneMinute   : 60000,
-    estEpoch    : 1456290000000
-}
+        return new Date().getTime() - epoch;
+    },
+    majorVersion: function() {
+        return Math.ceil(this.timeSinceEpoch() / this.atbTime.oneWeek);
+    },
+    minorVersion: function() {
+        return Math.ceil(this.timeSinceEpoch() % this.atbTime.oneWeek / this.atbTime.oneDay);
+    },
+    atbDelta: function(atb) {
+        var ogMajorVersion = atb.split('-')[0].slice(1),
+            ogMinorVersion = atb.split('-')[1],
+            majorVersion = this.majorVersion(),
+            minorVersion = this.minorVersion(),
+            majorDiff = majorVersion - ogMajorVersion,
+            minorDiff = Math.abs(minorVersion - ogMinorVersion);
 
-var timeSinceEpoch = getTimeSinceEpoch(),
-    majorVersion = Math.ceil(timeSinceEpoch / atbTime.oneWeek),
-    minorVersion = Math.ceil(timeSinceEpoch % atbTime.oneWeek / atbTime.oneDay);
-
-
-function getTimeSinceEpoch() {
-    var localDate = new Date(),
-        localTime = localDate.getTime(),
-        utcTime = localTime + (localDate.getTimezoneOffset() * atbTime.oneMinute),
-        est = new Date(utcTime + (atbTime.oneHour * -5)),
-        dstStartDay = 13 - ((est.getFullYear() - 2016) % 6),
-        dstStopDay = 6 - ((est.getFullYear() - 2016) % 6),
-        isDST = (est.getMonth() > 2 || (est.getMonth() == 2 && est.getDate() >= dstStartDay)) && (est.getMonth() < 10 || (est.getMonth() == 10 && est.getDate() < dstStopDay)),
-        epoch = isDST ? atbTime.estEpoch - atbTime.oneHour : atbTime.estEpoch;
-
-    return new Date().getTime() - epoch;
-}
-
-// caluclate the current ATB on install
-exports.install = function () {
-    return 'v' + majorVersion + '-' + minorVersion;
-}
-
-// caluclate the day of churn on uninstall
-exports.uninstall = function () {
-    var ogMajorVersion = ss.storage.atb.split('-')[0].slice(1),
-        ogMinorVersion = ss.storage.atb.split('-')[1],
-        majorDiff = majorVersion - ogMajorVersion,
-        minorDiff = Math.abs(minorVersion - ogMinorVersion),
-        atbDelta = majorDiff > 0 ? (7 * majorDiff) + minorDiff : minorDiff;
-
-    return atbDelta;
+    return majorDiff > 0 ? (7 * majorDiff) + minorDiff : minorDiff;
+    }
 
 }

--- a/lib/ddg-atbgen.js
+++ b/lib/ddg-atbgen.js
@@ -54,8 +54,8 @@ exports.uninstall = function () {
     var ogMajorVersion = ss.storage.atb.split('-')[0].slice(1),
         ogMinorVersion = ss.storage.atb.split('-')[1],
         majorDiff = majorVersion - ogMajorVersion,
-        minorDiff = minorVersion - ogMinorVersion,
-        dayOfChurn = majorDiff > 0 ? (7 * majorDiff) + Math.abs(minorDiff) : minorDiff;
+        minorDiff = Math.abs(minorVersion - ogMinorVersion),
+        dayOfChurn = majorDiff > 0 ? (7 * majorDiff) + minorDiff : minorDiff;
 
     return dayOfChurn;
 

--- a/lib/ddg-atbgen.js
+++ b/lib/ddg-atbgen.js
@@ -55,8 +55,8 @@ exports.uninstall = function () {
         ogMinorVersion = ss.storage.atb.split('-')[1],
         majorDiff = majorVersion - ogMajorVersion,
         minorDiff = Math.abs(minorVersion - ogMinorVersion),
-        dayOfChurn = majorDiff > 0 ? (7 * majorDiff) + minorDiff : minorDiff;
+        atbDelta = majorDiff > 0 ? (7 * majorDiff) + minorDiff : minorDiff;
 
-    return dayOfChurn;
+    return atbDelta;
 
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -33,13 +33,15 @@ var ATB = require("./ddg-atb");
 var nopopup = require("./ddg-nopopup");
 var noatb = require("./ddg-noatb");
 var atbgrabber = require("./ddg-atbgrabber");
+var atbgen = require("./ddg-atbgen");
+
 
 var {XPCOMUtils} = Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 var {Services} = Cu.import("resource://gre/modules/Services.jsm");
 var {NetUtil} = Cu.import("resource://gre/modules/NetUtil.jsm");
 
 
-const PARTNER_QUERY_ADDITION = '';
+const PARTNER_QUERY_ADDITION = '&t=partnerid';
 
 
 prefSet.on("ddg_default", onPrefChange);
@@ -99,7 +101,6 @@ function onPrefChange(prefName) {
     }
 }
 
-
 exports.main = function(options, callbacks) {
 
     VersionManager.addMajorUpdate("0.4.6");
@@ -124,24 +125,7 @@ exports.main = function(options, callbacks) {
     if (options.loadReason == "install") {
       // set the default ATB param
       if (ss.storage.atb == undefined) {
-          var oneWeek = 604800000,
-              oneDay = 86400000,
-              oneHour = 3600000,
-              oneMinute = 60000,
-              estEpoch = 1456290000000,
-              localDate = new Date(),
-              localTime = localDate.getTime(),
-              utcTime = localTime + (localDate.getTimezoneOffset() * oneMinute),
-              est = new Date(utcTime + (oneHour * -5)),
-              dstStartDay = 13 - ((est.getFullYear() - 2016) % 6),
-              dstStopDay = 6 - ((est.getFullYear() - 2016) % 6),
-              isDST = (est.getMonth() > 2 || (est.getMonth() == 2 && est.getDate() >= dstStartDay)) && (est.getMonth() < 10 || (est.getMonth() == 10 && est.getDate() < dstStopDay)),
-              epoch = isDST ? estEpoch - oneHour : estEpoch,
-              timeSinceEpoch = new Date().getTime() - epoch,
-              majorVersion = Math.ceil(timeSinceEpoch / oneWeek),
-              minorVersion = Math.ceil(timeSinceEpoch % oneWeek / oneDay);
-
-          ss.storage.atb = 'v' + majorVersion + '-' + minorVersion;
+        ss.storage.atb = atbgen.install();
       }
 
       ss.storage.installed_version = self.version;
@@ -227,7 +211,11 @@ exports.onUnload = function (reason) {
     }
 
     if (reason == 'uninstall') {
-        windows.open('https://www.surveymonkey.com/r/KFL2J7T');
+        var doc = atbgen.uninstall(),
+            surveyUrlParam = doc < 14 ? doc : 15,
+            surveyURL = 'https://www.surveymonkey.com/r/DOC_' + surveyUrlParam;
+
+        windows.open(surveyURL);
     }
 
     DDGAutocomplete.shutdown()

--- a/lib/main.js
+++ b/lib/main.js
@@ -125,7 +125,10 @@ exports.main = function(options, callbacks) {
     if (options.loadReason == "install") {
       // set the default ATB param
       if (ss.storage.atb == undefined) {
-        ss.storage.atb = atbgen.install();
+          var majorVersion = atbgen.calc.majorVersion(),
+              minorVersion = atbgen.calc.minorVersion();
+
+          ss.storage.atb = 'v' + majorVersion + '-' + minorVersion;
       }
 
       ss.storage.installed_version = self.version;
@@ -211,7 +214,7 @@ exports.onUnload = function (reason) {
     }
 
     if (reason == 'uninstall') {
-        var atbDelta = atbgen.uninstall(),
+        var atbDelta = atbgen.calc.atbDelta(ss.storage.atb),
             surveyUrlParam = atbDelta <= 14 ? atbDelta : 15,
             surveyURL = 'https://www.surveymonkey.com/r/DOC_' + surveyUrlParam;
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -41,7 +41,7 @@ var {Services} = Cu.import("resource://gre/modules/Services.jsm");
 var {NetUtil} = Cu.import("resource://gre/modules/NetUtil.jsm");
 
 
-const PARTNER_QUERY_ADDITION = '&t=partnerid';
+const PARTNER_QUERY_ADDITION = '';
 
 
 prefSet.on("ddg_default", onPrefChange);

--- a/lib/main.js
+++ b/lib/main.js
@@ -211,8 +211,8 @@ exports.onUnload = function (reason) {
     }
 
     if (reason == 'uninstall') {
-        var doc = atbgen.uninstall(),
-            surveyUrlParam = doc < 14 ? doc : 15,
+        var atbDelta = atbgen.uninstall(),
+            surveyUrlParam = atbDelta <= 14 ? atbDelta : 15,
             surveyURL = 'https://www.surveymonkey.com/r/DOC_' + surveyUrlParam;
 
         windows.open(surveyURL);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "description": "DuckDuckGo Plus",
     "author": "DuckDuckGo",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "title": "DuckDuckGo Plus",
     "id": "jid1-ZAdIEUB7XOzOJw@jetpack",
     "icon": {


### PR DESCRIPTION
@jdorweiler 

cc: @bsstoner, @mrshu 

This pull request calculates the ATB delta (current ATB on uninstall - original ATB on install) and passes the day of churn to the survey redirect URL.

I found it easier to develop if I repurposed the code that generates an ATB value if none can be assigned, rather than making a request. Let me know if this is the preferred way to go about it.