### PR TITLE
bug fix: remove appended '__' from atb value for calculations

### DIFF
--- a/lib/ddg-atbgen.js
+++ b/lib/ddg-atbgen.js
@@ -44,7 +44,7 @@ exports.calc = {
     },
     atbDelta: function(atb) {
         var ogMajorVersion = atb.split('-')[0].slice(1),
-            ogMinorVersion = atb.split('-')[1],
+            ogMinorVersion = atb.split('-')[1].slice(0, 1),
             majorVersion = this.majorVersion(),
             minorVersion = this.minorVersion(),
             majorDiff = majorVersion - ogMajorVersion,

--- a/lib/ddg-atbgen.js
+++ b/lib/ddg-atbgen.js
@@ -44,7 +44,7 @@ exports.calc = {
     },
     atbDelta: function(atb) {
         var ogMajorVersion = atb.split('-')[0].slice(1),
-            ogMinorVersion = atb.split('-')[1].slice(0, 1),
+            ogMinorVersion = atb.split('-')[1].match(/(\d+)/g)[0],
             majorVersion = this.majorVersion(),
             minorVersion = this.minorVersion(),
             majorDiff = majorVersion - ogMajorVersion,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "description": "DuckDuckGo Plus",
     "author": "DuckDuckGo",
-    "version": "1.1.2",
+    "version": "1.1.4",
     "title": "DuckDuckGo Plus",
     "id": "jid1-ZAdIEUB7XOzOJw@jetpack",
     "icon": {


### PR DESCRIPTION
This fixes the NaN issue that was defaulting surveys to DOC_15.